### PR TITLE
RS-2847: Remove unnecessary println

### DIFF
--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -467,10 +467,6 @@ impl<'a, W: 'a + Write + Seek, T: ColorType, K: TiffKind, D: Compression>
             }
         }
 
-        println!("Encoder write position: {}", encoder.writer.offset());
-
-
-
         Ok(ImageEncoder {
             encoder,
             chunk_count,

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -561,10 +561,6 @@ impl<'a, W: 'a + Write + Seek, T: ColorType, K: TiffKind, D: Compression>
                     self.chunk_offsets.push(K::convert_offset(offset)?);
                     self.chunk_byte_count.push(byte_count.try_into()?);
                     self.data_idx += 1;
-                    
-                    if self.data_idx % 100 == 0 {
-                        println!("{} chunks written", self.data_idx);
-                    }
                 }
                 tasks = Vec::new();
             }

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -578,7 +578,6 @@ fn test_big_tiled_image_directory() {
     // Create a test file in /tmp
     let tmp_file = tempfile::NamedTempFile::new().unwrap();
     let mut file = tmp_file.reopen().unwrap();
-    println!("Writing to file {:?}", file);
     //let mut file = Cursor::new(Vec::new());
 
     let image_width = 1000;


### PR DESCRIPTION
This println is spamming stdout when running test-data-generator to produce the test images.